### PR TITLE
Create gentoo-overlay-mali-x11.conf

### DIFF
--- a/gentoo-overlay-mali-x11.conf
+++ b/gentoo-overlay-mali-x11.conf
@@ -1,0 +1,12 @@
+[gentoo-overlay-mali-x11]
+#
+#/etc/portage/repos.conf/gentoo-overlay-mali-x11.conf
+# Overlay for Gentoo mali on the pine64/Rock64 media SBC's 
+# Maintainer: psychedup 
+
+location = /usr/local/portage/gentoo-overlay-mali-x11
+priority = 100
+sync-type = git
+sync-uri = https://github.com/psychedup/gentoo-overlay-mali-x11.git
+priority = 100
+auto-sync = yes


### PR DESCRIPTION
adds easy ability to use repo. 